### PR TITLE
Refaktorert config for sikkkerhetsvariabler for Aiven Kafka.

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedIT.kt
@@ -93,11 +93,11 @@ class BeskjedIT {
         val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.BESKJED, false)
         val kafkaConsumer = KafkaConsumer<Nokkel, Beskjed>(consumerProps)
 
-        val beskjedInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.BESKJEDINTERN, enableSecurity = false)
+        val beskjedInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.BESKJEDINTERN)
         val internalKafkaProducer = KafkaProducer<NokkelIntern, BeskjedIntern>(beskjedInternProducerProps)
         val internalEventProducer = Producer(Kafka.beskjedHovedTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.BESKJED, enableSecurity = false)
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.BESKJED)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(Kafka.feilresponsTopicName, feilresponsKafkaProducer)
 

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaTestUtil.kt
@@ -4,6 +4,7 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Environment
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.SecurityConfig
 import org.apache.avro.generic.GenericRecord
 import java.net.URL
 import java.util.*
@@ -50,12 +51,8 @@ object KafkaTestUtil {
                 influxdbPassword = "influxdbPasswordIkkeIBrukHer",
                 influxdbRetentionPolicy = "influxdbRetentionPolicyIkkeIBrukHer",
                 aivenBrokers = embeddedEnv.brokersURL.substringAfterLast("/"),
-                aivenTruststorePath = "kafkaTruststorePathIkkeIBrukHer",
-                aivenKeystorePath = "kafkaKeystorePathIkkeIBrukerHer",
-                aivenCredstorePassword = "kafkaCredstorePasswordIkkeIBrukHer",
                 aivenSchemaRegistry = embeddedEnv.schemaRegistry!!.url,
-                aivenSchemaRegistryUser = username,
-                aivenSchemaRegistryPassword = password
+                securityConfig = SecurityConfig(enabled = false)
         )
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/done/DoneIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/done/DoneIT.kt
@@ -93,11 +93,11 @@ class DoneIT {
         val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.DONE, enableSecurity = false)
         val kafkaConsumer = KafkaConsumer<Nokkel, Done>(consumerProps)
 
-        val doneInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.DONEINTERN, enableSecurity = false)
+        val doneInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.DONEINTERN)
         val internalKafkaProducer = KafkaProducer<NokkelIntern, DoneIntern>(doneInternProducerProps)
         val internalEventProducer = Producer(Kafka.doneHovedTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, enableSecurity = false)
+        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(Kafka.feilresponsTopicName, feilresponsKafkaProducer)
 

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveIT.kt
@@ -93,11 +93,11 @@ class OppgaveIT {
         val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVE, enableSecurity = false)
         val kafkaConsumer = KafkaConsumer<Nokkel, Oppgave>(consumerProps)
 
-        val oppgaveInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.OPPGAVEINTERN, enableSecurity = false)
+        val oppgaveInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.OPPGAVEINTERN)
         val internalKafkaProducer = KafkaProducer<NokkelIntern, OppgaveIntern>(oppgaveInternProducerProps)
         val internalEventProducer = Producer(Kafka.oppgaveHovedTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, enableSecurity = false)
+        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(Kafka.feilresponsTopicName, feilresponsKafkaProducer)
 

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringIT.kt
@@ -93,11 +93,11 @@ class StatusoppdateringIT {
         val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.STATUSOPPDATERING, enableSecurity = false)
         val kafkaConsumer = KafkaConsumer<Nokkel, Statusoppdatering>(consumerProps)
 
-        val statusoppdateringInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN, enableSecurity = false)
+        val statusoppdateringInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN)
         val internalKafkaProducer = KafkaProducer<NokkelIntern, StatusoppdateringIntern>(statusoppdateringInternProducerProps)
         val internalEventProducer = Producer(Kafka.statusoppdateringHovedTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, enableSecurity = false)
+        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(Kafka.feilresponsTopicName, feilresponsKafkaProducer)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/config/Kafka.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/config/Kafka.kt
@@ -54,7 +54,7 @@ object Kafka {
         }
     }
 
-    fun producerProps(env: Environment, type: Eventtype, enableSecurity: Boolean = isCurrentlyRunningOnNais()): Properties {
+    fun producerProps(env: Environment, type: Eventtype): Properties {
         return Properties().apply {
             put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, env.aivenBrokers)
             put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, env.aivenSchemaRegistry)
@@ -65,13 +65,13 @@ object Kafka {
             put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 40000)
             put(ProducerConfig.ACKS_CONFIG, "all")
             put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
-            if (enableSecurity) {
-                putAll(credentialPropsAiven(env))
+            if (env.securityConfig.enabled) {
+                putAll(credentialPropsAiven(env.securityConfig.variables!!))
             }
         }
     }
 
-    fun producerFeilresponsProps(env: Environment, eventtype: Eventtype, enableSecurity: Boolean = isCurrentlyRunningOnNais()): Properties {
+    fun producerFeilresponsProps(env: Environment, eventtype: Eventtype): Properties {
         return Properties().apply {
             put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, env.aivenBrokers)
             put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, env.aivenSchemaRegistry)
@@ -82,8 +82,8 @@ object Kafka {
             put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 40000)
             put(ProducerConfig.ACKS_CONFIG, "all")
             put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
-            if (enableSecurity) {
-                putAll(credentialPropsAiven(env))
+            if (env.securityConfig.enabled) {
+                putAll(credentialPropsAiven(env.securityConfig.variables!!))
             }
         }
     }
@@ -102,19 +102,19 @@ object Kafka {
             }
         }
     }
-    private fun credentialPropsAiven(env: Environment): Properties {
+    private fun credentialPropsAiven(securityVars: SecurityVars): Properties {
         return Properties().apply {
-            put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "${env.aivenSchemaRegistryUser}:${env.aivenSchemaRegistryPassword}")
+            put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "${securityVars.aivenSchemaRegistryUser}:${securityVars.aivenSchemaRegistryPassword}")
             put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
             put(SaslConfigs.SASL_MECHANISM, "PLAIN")
             put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL")
             put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "jks")
             put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12")
-            put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.aivenTruststorePath)
-            put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.aivenCredstorePassword)
-            put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, env.aivenKeystorePath)
-            put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, env.aivenCredstorePassword)
-            put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, env.aivenCredstorePassword)
+            put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, securityVars.aivenTruststorePath)
+            put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, securityVars.aivenCredstorePassword)
+            put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, securityVars.aivenKeystorePath)
+            put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, securityVars.aivenCredstorePassword)
+            put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, securityVars.aivenCredstorePassword)
             put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "")
         }
     }


### PR DESCRIPTION
Etter samme mønster som gjort i aggregatoren. Skrur av sikkerhet for Kafka når applikasjonen kjøres lokalt. Får ikke sikkerhetsoppsettet/variablene som Aiven Kafka krever til å fungere i docker-compose.