### PR TITLE
Tighten duplicates

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedInputIT.kt
@@ -1,0 +1,205 @@
+package no.nav.personbruker.brukernotifikasjonbestiller.beskjed
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.brukernotifikasjon.schemas.internal.BeskjedIntern
+import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
+import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
+import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
+import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.AvroBeskjedInputObjectMother.createBeskjedInput
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedInputEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.*
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventIdAndGroupId
+import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.collections.ArrayList
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BeskjedInputIT {
+    private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
+            KafkaTestTopics.beskjedInputTopicName,
+            KafkaTestTopics.beskjedInternTopicName,
+            KafkaTestTopics.feilresponsTopicName
+    ))
+    private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+
+    private val database = LocalPostgresDatabase()
+
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, BeskjedIntern>>()
+
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+
+    private val metricsReporter = StubMetricsReporter()
+    private val metricsCollector = MetricsCollector(metricsReporter)
+
+    private val goodEvents = createEvents(10)
+    private val badEvents = listOf(
+        createEventWithTooLongGroupId(),
+        createEventWithInvalidEventId(),
+        createEventWithDuplicateId(goodEvents)
+    )
+
+    private val beskjedEvents = goodEvents.toMutableList().apply {
+        addAll(badEvents)
+    }.toMap()
+
+    @BeforeAll
+    fun setup() {
+        embeddedEnv.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        embeddedEnv.tearDown()
+    }
+
+    @Test
+    fun `Started Kafka instance in memory`() {
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
+    }
+
+    @Test
+    fun `Should read Beskjed-events and send to hoved-topic or error response topic as appropriate`() {
+        runBlocking {
+            KafkaTestUtil.produceEventsInput(testEnvironment, KafkaTestTopics.beskjedInputTopicName, beskjedEvents)
+        } shouldBeEqualTo true
+
+        `Read all Beskjed-events from our input-topic and verify that they have been sent to the main-topic`()
+
+        capturedInternalRecords.size `should be equal to` goodEvents.size
+        capturedErrorResponseRecords.size `should be equal to` badEvents.size
+    }
+
+    fun `Read all Beskjed-events from our input-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.BESKJED)
+        val kafkaConsumer = KafkaConsumer<NokkelInput, BeskjedInput>(consumerProps)
+
+        val beskjedInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.BESKJEDINTERN, TopicSource.AIVEN)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, BeskjedIntern>(beskjedInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.beskjedInternTopicName, internalKafkaProducer)
+
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.BESKJED, TopicSource.AIVEN)
+        val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
+        val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
+
+        val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.BESKJED, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+
+        val eventService = BeskjedInputEventService(metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.beskjedInputTopicName, kafkaConsumer, eventService)
+
+        internalKafkaProducer.initTransactions()
+        feilresponsKafkaProducer.initTransactions()
+        runBlocking {
+            consumer.startPolling()
+
+            `Wait until all beskjed events have been received by target topic`()
+            `Wait until bad event has been received by error topic`()
+
+            consumer.stopPolling()
+        }
+    }
+
+
+    private fun `Wait until all beskjed events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.BESKJEDINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, BeskjedIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, BeskjedIntern>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.beskjedInternTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var currentNumberOfRecords = 0
+
+        targetConsumer.startPolling()
+
+        while (currentNumberOfRecords < goodEvents.size) {
+            runBlocking {
+                currentNumberOfRecords = capturingProcessor.getEvents().size
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedInternalRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun `Wait until bad event has been received by error topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
+        val targetKafkaConsumer = KafkaConsumer<NokkelFeilrespons, Feilrespons>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelFeilrespons, Feilrespons>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.feilresponsTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var receivedEvent = false
+
+        targetConsumer.startPolling()
+
+        while (!receivedEvent) {
+            runBlocking {
+                receivedEvent = capturingProcessor.getEvents().isNotEmpty()
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedErrorResponseRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun createEvents(number: Int) = (1..number).map {
+        val eventId = UUID.randomUUID().toString()
+
+        createNokkelInputWithEventIdAndGroupId(eventId, it.toString()) to createBeskjedInput()
+    }
+
+    private fun createEventWithTooLongGroupId(): Pair<NokkelInput, BeskjedInput> {
+        val eventId = UUID.randomUUID().toString()
+        val groupId = "groupId".repeat(100)
+
+        return createNokkelInputWithEventIdAndGroupId(eventId, groupId) to createBeskjedInput()
+    }
+
+    private fun createEventWithInvalidEventId(): Pair<NokkelInput, BeskjedInput> {
+        val eventId = "notUuidOrUlid"
+
+        return createNokkelInputWithEventId(eventId) to createBeskjedInput()
+    }
+
+    private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, BeskjedInput>>): Pair<NokkelInput, BeskjedInput> {
+        val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
+
+        return return createNokkelInputWithEventId(existingEventId) to createBeskjedInput()
+    }
+}

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedInputIT.kt
@@ -200,6 +200,6 @@ class BeskjedInputIT {
     private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, BeskjedInput>>): Pair<NokkelInput, BeskjedInput> {
         val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
 
-        return return createNokkelInputWithEventId(existingEventId) to createBeskjedInput()
+        return createNokkelInputWithEventId(existingEventId) to createBeskjedInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedLegacyIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/beskjed/BeskjedLegacyIT.kt
@@ -1,11 +1,11 @@
-package no.nav.personbruker.brukernotifikasjonbestiller.innboks
+package no.nav.personbruker.brukernotifikasjonbestiller.beskjed
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import no.nav.brukernotifikasjon.schemas.Innboks
+import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.internal.BeskjedIntern
 import no.nav.brukernotifikasjon.schemas.output.Feilrespons
-import no.nav.brukernotifikasjon.schemas.internal.InnboksIntern
 import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.common.KafkaEnvironment
@@ -15,9 +15,12 @@ import no.nav.personbruker.brukernotifikasjonbestiller.common.getClient
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.AvroBeskjedLegacyObjectMother.createBeskjedLegacyWithGrupperingsId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedLegacyEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedLegacyTransformer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
@@ -26,9 +29,6 @@ import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuse
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.AvroInnboksLegacyObjectMother.createInnboksLegacyWithGrupperingsId
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.InnboksLegacyEventService
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.InnboksLegacyTransformer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollectorLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameResolver
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameScrubber
@@ -45,36 +45,37 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class InnboksIT {
-
+class BeskjedLegacyIT {
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
-            KafkaTestTopics.innboksLegacyTopicName,
-            KafkaTestTopics.innboksInternTopicName,
+            KafkaTestTopics.beskjedLegacyTopicName,
+            KafkaTestTopics.beskjedInternTopicName,
             KafkaTestTopics.feilresponsTopicName
     ))
     private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
 
     private val database = LocalPostgresDatabase()
 
-    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, InnboksIntern>>()
-    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, BeskjedIntern>>()
 
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
     private val producerNameAlias = "dittnav"
+
     private val client = getClient(producerNameAlias)
     private val metricsReporter = StubMetricsReporter()
     private val nameResolver = ProducerNameResolver(client, testEnvironment.eventHandlerURL)
     private val nameScrubber = ProducerNameScrubber(nameResolver)
     private val metricsCollector = MetricsCollectorLegacy(metricsReporter, nameScrubber)
     private val producerServiceUser = "dummySystembruker"
+
     private val producerNamespace = "namespace"
     private val producerAppName = "appName"
     private val mapper = ServiceUserMapper(mapOf(producerServiceUser to NamespaceAppName(producerNamespace, producerAppName)))
-    private val innboksTransformer = InnboksLegacyTransformer(mapper)
+    private val beskjedTransformer = BeskjedLegacyTransformer(mapper)
     private val feilresponsTransformer = FeilresponsLegacyTransformer(mapper)
 
     private val goodEvents = createEvents(10)
     private val badEvents = listOf(createEventWithTooLongGroupId("bad"))
-    private val innboksEvents = goodEvents.toMutableList().apply {
+    private val beskjedEvents = goodEvents.toMutableList().apply {
         addAll(badEvents)
     }.toMap()
 
@@ -94,55 +95,55 @@ class InnboksIT {
     }
 
     @Test
-    fun `Should read Innboks-events and send to hoved-topic or error response topic as appropriate`() {
+    fun `Should read Beskjed-events and send to hoved-topic or error response topic as appropriate`() {
         runBlocking {
-            KafkaTestUtil.produceEvents(testEnvironment, KafkaTestTopics.innboksLegacyTopicName, innboksEvents)
+            KafkaTestUtil.produceEventsLegacy(testEnvironment, KafkaTestTopics.beskjedLegacyTopicName, beskjedEvents)
         } shouldBeEqualTo true
 
-        `Read all Innboks-events from our input-topic and verify that they have been sent to the main-topic`()
+        `Read all Beskjed-events from our legacy-topic and verify that they have been sent to the main-topic`()
 
         capturedInternalRecords.size `should be equal to` goodEvents.size
         capturedErrorResponseRecords.size `should be equal to` badEvents.size
     }
 
 
-    fun `Read all Innboks-events from our input-topic and verify that they have been sent to the main-topic`() {
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKS)
-        val kafkaConsumer = KafkaConsumer<Nokkel, Innboks>(consumerProps)
+    fun `Read all Beskjed-events from our legacy-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.BESKJED)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Beskjed>(consumerProps)
 
-        val innboksInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.INNBOKSINTERN, TopicSource.ON_PREM)
-        val internalKafkaProducer = KafkaProducer<NokkelIntern, InnboksIntern>(innboksInternProducerProps)
-        val internalEventProducer = Producer(KafkaTestTopics.innboksInternTopicName, internalKafkaProducer)
+        val beskjedInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.BESKJEDINTERN, TopicSource.ON_PREM)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, BeskjedIntern>(beskjedInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.beskjedInternTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.INNBOKS, TopicSource.ON_PREM)
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.BESKJED, TopicSource.ON_PREM)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
 
         val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository)
-        val eventDispatcher = EventDispatcher(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.BESKJED, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
 
-        val eventService = InnboksLegacyEventService(innboksTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
-        val consumer = Consumer(KafkaTestTopics.innboksLegacyTopicName, kafkaConsumer, eventService)
+        val eventService = BeskjedLegacyEventService(beskjedTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.beskjedLegacyTopicName, kafkaConsumer, eventService)
 
         internalKafkaProducer.initTransactions()
         feilresponsKafkaProducer.initTransactions()
         runBlocking {
             consumer.startPolling()
 
-            `Wait until all innboks events have been received by target topic`()
+            `Wait until all beskjed events have been received by target topic`()
             `Wait until bad event has been received by error topic`()
 
             consumer.stopPolling()
         }
     }
 
-    private fun `Wait until all innboks events have been received by target topic`() {
-        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKSINTERN)
-        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, InnboksIntern>(targetConsumerProps)
-        val capturingProcessor = CapturingEventProcessor<NokkelIntern, InnboksIntern>()
+    private fun `Wait until all beskjed events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.BESKJEDINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, BeskjedIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, BeskjedIntern>()
 
-        val targetConsumer = Consumer(KafkaTestTopics.innboksInternTopicName, targetKafkaConsumer, capturingProcessor)
+        val targetConsumer = Consumer(KafkaTestTopics.beskjedInternTopicName, targetKafkaConsumer, capturingProcessor)
 
         var currentNumberOfRecords = 0
 
@@ -161,7 +162,6 @@ class InnboksIT {
 
         capturedInternalRecords.addAll(capturingProcessor.getEvents())
     }
-
 
     private fun `Wait until bad event has been received by error topic`() {
         val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
@@ -189,12 +189,12 @@ class InnboksIT {
     }
 
     private fun createEvents(number: Int) = (1..number).map {
-        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createInnboksLegacyWithGrupperingsId(it.toString())
+        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createBeskjedLegacyWithGrupperingsId(it.toString())
     }
 
-    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Innboks> {
+    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Beskjed> {
         val groupId = "groupId".repeat(100)
 
-        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createInnboksLegacyWithGrupperingsId(groupId)
+        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createBeskjedLegacyWithGrupperingsId(groupId)
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/brukernotifikasjonbestilling/BrukernotifikasjonbestillingRepositoryTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/brukernotifikasjonbestilling/BrukernotifikasjonbestillingRepositoryTest.kt
@@ -9,7 +9,7 @@ import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjo
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.deleteAllBrukernotifikasjonbestilling
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.AvroNokkelInternObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 import org.amshove.kluent.`should be equal to`
@@ -20,7 +20,7 @@ class BrukernotifikasjonbestillingRepositoryTest {
 
     private val database = LocalPostgresDatabase()
     private val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
-    private val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+    private val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
 
     private val eventBeskjed_0 = BrukernotifikasjonbestillingObjectMother.createBrukernotifikasjonbestilling(eventId = "eventId-0", systembruker = "systembruker-0", eventtype = Eventtype.BESKJED, fodselsnummer = "0")
     private val eventBeskjed_1 = BrukernotifikasjonbestillingObjectMother.createBrukernotifikasjonbestilling(eventId = "eventId-1", systembruker = "systembruker-1", eventtype = Eventtype.BESKJED, fodselsnummer = "123")

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaProducerUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaProducerUtil.kt
@@ -4,6 +4,7 @@ package no.nav.personbruker.brukernotifikasjonbestiller.common.kafka
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import kotlinx.coroutines.withTimeoutOrNull
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
@@ -20,6 +21,34 @@ object KafkaProducerUtil {
     ): Boolean =
             try {
                 KafkaProducer<Nokkel, GenericRecord>(
+                        Properties().apply {
+                            set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
+                            set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaAvroProduce")
+                            set(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
+                            set(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
+                            set(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+                            set(ProducerConfig.ACKS_CONFIG, "all")
+                            set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
+                            set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
+                        }
+                ).use { p ->
+                    withTimeoutOrNull(10_000) {
+                        data.forEach { k, v -> p.send(ProducerRecord(topic, k, v)).get() }
+                        true
+                    } ?: false
+                }
+            } catch (e: Exception) {
+                false
+            }
+
+    suspend fun kafkaAvroProduceInput(
+            brokersURL: String,
+            schemaRegistryUrl: String,
+            topic: String,
+            data: Map<NokkelInput, GenericRecord>
+    ): Boolean =
+            try {
+                KafkaProducer<NokkelInput, GenericRecord>(
                         Properties().apply {
                             set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
                             set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaAvroProduce")

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/common/kafka/KafkaTestUtil.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.brukernotifikasjonbestiller.common.kafka
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Environment
@@ -73,8 +74,16 @@ object KafkaTestUtil {
         )
     }
 
-    suspend fun produceEvents(env: Environment, topicName: String, events: Map<Nokkel, GenericRecord>): Boolean {
+    suspend fun produceEventsLegacy(env: Environment, topicName: String, events: Map<Nokkel, GenericRecord>): Boolean {
         return KafkaProducerUtil.kafkaAvroProduceLegacy(
+                env.bootstrapServers,
+                env.schemaRegistryUrl,
+                topicName,
+                events)
+    }
+
+    suspend fun produceEventsInput(env: Environment, topicName: String, events: Map<NokkelInput, GenericRecord>): Boolean {
+        return KafkaProducerUtil.kafkaAvroProduceInput(
                 env.bootstrapServers,
                 env.schemaRegistryUrl,
                 topicName,

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/done/DoneInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/done/DoneInputIT.kt
@@ -231,6 +231,6 @@ class DoneInputIT {
     private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, DoneInput>>): Pair<NokkelInput, DoneInput> {
         val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
 
-        return return AvroNokkelInputObjectMother.createNokkelInputWithEventId(existingEventId) to createDoneInput()
+        return AvroNokkelInputObjectMother.createNokkelInputWithEventId(existingEventId) to createDoneInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksInputIT.kt
@@ -200,6 +200,6 @@ class InnboksInputIT {
     private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, InnboksInput>>): Pair<NokkelInput, InnboksInput> {
         val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
 
-        return return createNokkelInputWithEventId(existingEventId) to createInnboksInput()
+        return createNokkelInputWithEventId(existingEventId) to createInnboksInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksInputIT.kt
@@ -1,0 +1,205 @@
+package no.nav.personbruker.brukernotifikasjonbestiller.innboks
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.input.InnboksInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.brukernotifikasjon.schemas.internal.InnboksIntern
+import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
+import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
+import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
+import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.AvroInnboksInputObjectMother.createInnboksInput
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.InnboksInputEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.*
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventIdAndGroupId
+import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.collections.ArrayList
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InnboksInputIT {
+    private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
+            KafkaTestTopics.innboksInputTopicName,
+            KafkaTestTopics.innboksInternTopicName,
+            KafkaTestTopics.feilresponsTopicName
+    ))
+    private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+
+    private val database = LocalPostgresDatabase()
+
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, InnboksIntern>>()
+
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+
+    private val metricsReporter = StubMetricsReporter()
+    private val metricsCollector = MetricsCollector(metricsReporter)
+
+    private val goodEvents = createEvents(10)
+    private val badEvents = listOf(
+        createEventWithTooLongGroupId(),
+        createEventWithInvalidEventId(),
+        createEventWithDuplicateId(goodEvents)
+    )
+
+    private val innboksEvents = goodEvents.toMutableList().apply {
+        addAll(badEvents)
+    }.toMap()
+
+    @BeforeAll
+    fun setup() {
+        embeddedEnv.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        embeddedEnv.tearDown()
+    }
+
+    @Test
+    fun `Started Kafka instance in memory`() {
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
+    }
+
+    @Test
+    fun `Should read Innboks-events and send to hoved-topic or error response topic as appropriate`() {
+        runBlocking {
+            KafkaTestUtil.produceEventsInput(testEnvironment, KafkaTestTopics.innboksInputTopicName, innboksEvents)
+        } shouldBeEqualTo true
+
+        `Read all Innboks-events from our input-topic and verify that they have been sent to the main-topic`()
+
+        capturedInternalRecords.size `should be equal to` goodEvents.size
+        capturedErrorResponseRecords.size `should be equal to` badEvents.size
+    }
+
+    fun `Read all Innboks-events from our input-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKS)
+        val kafkaConsumer = KafkaConsumer<NokkelInput, InnboksInput>(consumerProps)
+
+        val innboksInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.INNBOKSINTERN, TopicSource.AIVEN)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, InnboksIntern>(innboksInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.innboksInternTopicName, internalKafkaProducer)
+
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.INNBOKS, TopicSource.AIVEN)
+        val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
+        val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
+
+        val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+
+        val eventService = InnboksInputEventService(metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.innboksInputTopicName, kafkaConsumer, eventService)
+
+        internalKafkaProducer.initTransactions()
+        feilresponsKafkaProducer.initTransactions()
+        runBlocking {
+            consumer.startPolling()
+
+            `Wait until all innboks events have been received by target topic`()
+            `Wait until bad event has been received by error topic`()
+
+            consumer.stopPolling()
+        }
+    }
+
+
+    private fun `Wait until all innboks events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKSINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, InnboksIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, InnboksIntern>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.innboksInternTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var currentNumberOfRecords = 0
+
+        targetConsumer.startPolling()
+
+        while (currentNumberOfRecords < goodEvents.size) {
+            runBlocking {
+                currentNumberOfRecords = capturingProcessor.getEvents().size
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedInternalRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun `Wait until bad event has been received by error topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
+        val targetKafkaConsumer = KafkaConsumer<NokkelFeilrespons, Feilrespons>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelFeilrespons, Feilrespons>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.feilresponsTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var receivedEvent = false
+
+        targetConsumer.startPolling()
+
+        while (!receivedEvent) {
+            runBlocking {
+                receivedEvent = capturingProcessor.getEvents().isNotEmpty()
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedErrorResponseRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun createEvents(number: Int) = (1..number).map {
+        val eventId = UUID.randomUUID().toString()
+
+        createNokkelInputWithEventIdAndGroupId(eventId, it.toString()) to createInnboksInput()
+    }
+
+    private fun createEventWithTooLongGroupId(): Pair<NokkelInput, InnboksInput> {
+        val eventId = UUID.randomUUID().toString()
+        val groupId = "groupId".repeat(100)
+
+        return createNokkelInputWithEventIdAndGroupId(eventId, groupId) to createInnboksInput()
+    }
+
+    private fun createEventWithInvalidEventId(): Pair<NokkelInput, InnboksInput> {
+        val eventId = "notUuidOrUlid"
+
+        return createNokkelInputWithEventId(eventId) to createInnboksInput()
+    }
+
+    private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, InnboksInput>>): Pair<NokkelInput, InnboksInput> {
+        val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
+
+        return return createNokkelInputWithEventId(existingEventId) to createInnboksInput()
+    }
+}

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksLegacyIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/innboks/InnboksLegacyIT.kt
@@ -1,13 +1,13 @@
-package no.nav.personbruker.brukernotifikasjonbestiller.oppgave
+package no.nav.personbruker.brukernotifikasjonbestiller.innboks
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Innboks
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.brukernotifikasjon.schemas.Oppgave
 import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.internal.InnboksIntern
 import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
-import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
 import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
@@ -17,7 +17,7 @@ import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTop
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
@@ -26,14 +26,14 @@ import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuse
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.AvroInnboksLegacyObjectMother.createInnboksLegacyWithGrupperingsId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.InnboksLegacyEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.innboks.InnboksLegacyTransformer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollectorLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameResolver
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.TopicSource
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelLegacyObjectMother.createNokkelLegacyWithEventIdAndSystembruker
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.AvroOppgaveLegacyObjectMother.createOppgaveLegacyWithGrupperingsId
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.OppgaveLegacyEventService
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.OppgaveLegacyTransformer
 import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
@@ -45,17 +45,18 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class OppgaveIT {
+class InnboksLegacyIT {
+
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
-            KafkaTestTopics.oppgaveLegacyTopicName,
-            KafkaTestTopics.oppgaveInternTopicName,
+            KafkaTestTopics.innboksLegacyTopicName,
+            KafkaTestTopics.innboksInternTopicName,
             KafkaTestTopics.feilresponsTopicName
     ))
     private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
 
     private val database = LocalPostgresDatabase()
 
-    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, OppgaveIntern>>()
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, InnboksIntern>>()
     private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
 
     private val producerNameAlias = "dittnav"
@@ -68,12 +69,12 @@ class OppgaveIT {
     private val producerNamespace = "namespace"
     private val producerAppName = "appName"
     private val mapper = ServiceUserMapper(mapOf(producerServiceUser to NamespaceAppName(producerNamespace, producerAppName)))
-    private val oppgaveTransformer = OppgaveLegacyTransformer(mapper)
+    private val innboksTransformer = InnboksLegacyTransformer(mapper)
     private val feilresponsTransformer = FeilresponsLegacyTransformer(mapper)
 
     private val goodEvents = createEvents(10)
     private val badEvents = listOf(createEventWithTooLongGroupId("bad"))
-    private val oppgaveEvents = goodEvents.toMutableList().apply {
+    private val innboksEvents = goodEvents.toMutableList().apply {
         addAll(badEvents)
     }.toMap()
 
@@ -93,55 +94,55 @@ class OppgaveIT {
     }
 
     @Test
-    fun `Should read Oppgave-events and send to hoved-topic or error response topic as appropriate`() {
+    fun `Should read Innboks-events and send to hoved-topic or error response topic as appropriate`() {
         runBlocking {
-            KafkaTestUtil.produceEvents(testEnvironment, KafkaTestTopics.oppgaveLegacyTopicName, oppgaveEvents)
+            KafkaTestUtil.produceEventsLegacy(testEnvironment, KafkaTestTopics.innboksLegacyTopicName, innboksEvents)
         } shouldBeEqualTo true
 
-        `Read all Oppgave-events from our input-topic and verify that they have been sent to the main-topic`()
+        `Read all Innboks-events from our legacy-topic and verify that they have been sent to the main-topic`()
 
         capturedInternalRecords.size `should be equal to` goodEvents.size
         capturedErrorResponseRecords.size `should be equal to` badEvents.size
     }
 
 
-    fun `Read all Oppgave-events from our input-topic and verify that they have been sent to the main-topic`() {
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVE)
-        val kafkaConsumer = KafkaConsumer<Nokkel, Oppgave>(consumerProps)
+    fun `Read all Innboks-events from our legacy-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKS)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Innboks>(consumerProps)
 
-        val oppgaveInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.OPPGAVEINTERN, TopicSource.ON_PREM)
-        val internalKafkaProducer = KafkaProducer<NokkelIntern, OppgaveIntern>(oppgaveInternProducerProps)
-        val internalEventProducer = Producer(KafkaTestTopics.oppgaveInternTopicName, internalKafkaProducer)
+        val innboksInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.INNBOKSINTERN, TopicSource.ON_PREM)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, InnboksIntern>(innboksInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.innboksInternTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, TopicSource.ON_PREM)
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.INNBOKS, TopicSource.ON_PREM)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
 
         val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository)
-        val eventDispatcher = EventDispatcher(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
 
-        val eventService = OppgaveLegacyEventService(oppgaveTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
-        val consumer = Consumer(KafkaTestTopics.oppgaveLegacyTopicName, kafkaConsumer, eventService)
+        val eventService = InnboksLegacyEventService(innboksTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.innboksLegacyTopicName, kafkaConsumer, eventService)
 
         internalKafkaProducer.initTransactions()
         feilresponsKafkaProducer.initTransactions()
         runBlocking {
             consumer.startPolling()
 
-            `Wait until all oppgave events have been received by target topic`()
+            `Wait until all innboks events have been received by target topic`()
             `Wait until bad event has been received by error topic`()
 
             consumer.stopPolling()
         }
     }
 
-    private fun `Wait until all oppgave events have been received by target topic`() {
-        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVEINTERN)
-        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, OppgaveIntern>(targetConsumerProps)
-        val capturingProcessor = CapturingEventProcessor<NokkelIntern, OppgaveIntern>()
+    private fun `Wait until all innboks events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.INNBOKSINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, InnboksIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, InnboksIntern>()
 
-        val targetConsumer = Consumer(KafkaTestTopics.oppgaveInternTopicName, targetKafkaConsumer, capturingProcessor)
+        val targetConsumer = Consumer(KafkaTestTopics.innboksInternTopicName, targetKafkaConsumer, capturingProcessor)
 
         var currentNumberOfRecords = 0
 
@@ -188,12 +189,12 @@ class OppgaveIT {
     }
 
     private fun createEvents(number: Int) = (1..number).map {
-        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createOppgaveLegacyWithGrupperingsId(it.toString())
+        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createInnboksLegacyWithGrupperingsId(it.toString())
     }
 
-    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Oppgave> {
+    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Innboks> {
         val groupId = "groupId".repeat(100)
 
-        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createOppgaveLegacyWithGrupperingsId(groupId)
+        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createInnboksLegacyWithGrupperingsId(groupId)
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveInputIT.kt
@@ -1,0 +1,205 @@
+package no.nav.personbruker.brukernotifikasjonbestiller.oppgave
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.input.OppgaveInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
+import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
+import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
+import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
+import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.AvroOppgaveInputObjectMother.createOppgaveInput
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.OppgaveInputEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.*
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventIdAndGroupId
+import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.collections.ArrayList
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OppgaveInputIT {
+    private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
+            KafkaTestTopics.oppgaveInputTopicName,
+            KafkaTestTopics.oppgaveInternTopicName,
+            KafkaTestTopics.feilresponsTopicName
+    ))
+    private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+
+    private val database = LocalPostgresDatabase()
+
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, OppgaveIntern>>()
+
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+
+    private val metricsReporter = StubMetricsReporter()
+    private val metricsCollector = MetricsCollector(metricsReporter)
+
+    private val goodEvents = createEvents(10)
+    private val badEvents = listOf(
+        createEventWithTooLongGroupId(),
+        createEventWithInvalidEventId(),
+        createEventWithDuplicateId(goodEvents)
+    )
+
+    private val oppgaveEvents = goodEvents.toMutableList().apply {
+        addAll(badEvents)
+    }.toMap()
+
+    @BeforeAll
+    fun setup() {
+        embeddedEnv.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        embeddedEnv.tearDown()
+    }
+
+    @Test
+    fun `Started Kafka instance in memory`() {
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
+    }
+
+    @Test
+    fun `Should read Oppgave-events and send to hoved-topic or error response topic as appropriate`() {
+        runBlocking {
+            KafkaTestUtil.produceEventsInput(testEnvironment, KafkaTestTopics.oppgaveInputTopicName, oppgaveEvents)
+        } shouldBeEqualTo true
+
+        `Read all Oppgave-events from our input-topic and verify that they have been sent to the main-topic`()
+
+        capturedInternalRecords.size `should be equal to` goodEvents.size
+        capturedErrorResponseRecords.size `should be equal to` badEvents.size
+    }
+
+    fun `Read all Oppgave-events from our input-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVE)
+        val kafkaConsumer = KafkaConsumer<NokkelInput, OppgaveInput>(consumerProps)
+
+        val oppgaveInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.OPPGAVEINTERN, TopicSource.AIVEN)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, OppgaveIntern>(oppgaveInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.oppgaveInternTopicName, internalKafkaProducer)
+
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.OPPGAVE, TopicSource.AIVEN)
+        val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
+        val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
+
+        val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+
+        val eventService = OppgaveInputEventService(metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.oppgaveInputTopicName, kafkaConsumer, eventService)
+
+        internalKafkaProducer.initTransactions()
+        feilresponsKafkaProducer.initTransactions()
+        runBlocking {
+            consumer.startPolling()
+
+            `Wait until all oppgave events have been received by target topic`()
+            `Wait until bad event has been received by error topic`()
+
+            consumer.stopPolling()
+        }
+    }
+
+
+    private fun `Wait until all oppgave events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVEINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, OppgaveIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, OppgaveIntern>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.oppgaveInternTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var currentNumberOfRecords = 0
+
+        targetConsumer.startPolling()
+
+        while (currentNumberOfRecords < goodEvents.size) {
+            runBlocking {
+                currentNumberOfRecords = capturingProcessor.getEvents().size
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedInternalRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun `Wait until bad event has been received by error topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
+        val targetKafkaConsumer = KafkaConsumer<NokkelFeilrespons, Feilrespons>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelFeilrespons, Feilrespons>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.feilresponsTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var receivedEvent = false
+
+        targetConsumer.startPolling()
+
+        while (!receivedEvent) {
+            runBlocking {
+                receivedEvent = capturingProcessor.getEvents().isNotEmpty()
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedErrorResponseRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun createEvents(number: Int) = (1..number).map {
+        val eventId = UUID.randomUUID().toString()
+
+        createNokkelInputWithEventIdAndGroupId(eventId, it.toString()) to createOppgaveInput()
+    }
+
+    private fun createEventWithTooLongGroupId(): Pair<NokkelInput, OppgaveInput> {
+        val eventId = UUID.randomUUID().toString()
+        val groupId = "groupId".repeat(100)
+
+        return createNokkelInputWithEventIdAndGroupId(eventId, groupId) to createOppgaveInput()
+    }
+
+    private fun createEventWithInvalidEventId(): Pair<NokkelInput, OppgaveInput> {
+        val eventId = "notUuidOrUlid"
+
+        return createNokkelInputWithEventId(eventId) to createOppgaveInput()
+    }
+
+    private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, OppgaveInput>>): Pair<NokkelInput, OppgaveInput> {
+        val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
+
+        return return createNokkelInputWithEventId(existingEventId) to createOppgaveInput()
+    }
+}

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveInputIT.kt
@@ -200,6 +200,6 @@ class OppgaveInputIT {
     private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, OppgaveInput>>): Pair<NokkelInput, OppgaveInput> {
         val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
 
-        return return createNokkelInputWithEventId(existingEventId) to createOppgaveInput()
+        return createNokkelInputWithEventId(existingEventId) to createOppgaveInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveLegacyIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/oppgave/OppgaveLegacyIT.kt
@@ -1,0 +1,199 @@
+package no.nav.personbruker.brukernotifikasjonbestiller.oppgave
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.Oppgave
+import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
+import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
+import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
+import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
+import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
+import no.nav.personbruker.brukernotifikasjonbestiller.common.getClient
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.NamespaceAppName
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollectorLegacy
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.TopicSource
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelLegacyObjectMother.createNokkelLegacyWithEventIdAndSystembruker
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.AvroOppgaveLegacyObjectMother.createOppgaveLegacyWithGrupperingsId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.OppgaveLegacyEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.oppgave.OppgaveLegacyTransformer
+import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OppgaveLegacyIT {
+    private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
+            KafkaTestTopics.oppgaveLegacyTopicName,
+            KafkaTestTopics.oppgaveInternTopicName,
+            KafkaTestTopics.feilresponsTopicName
+    ))
+    private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+
+    private val database = LocalPostgresDatabase()
+
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, OppgaveIntern>>()
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+
+    private val producerNameAlias = "dittnav"
+    private val client = getClient(producerNameAlias)
+    private val metricsReporter = StubMetricsReporter()
+    private val nameResolver = ProducerNameResolver(client, testEnvironment.eventHandlerURL)
+    private val nameScrubber = ProducerNameScrubber(nameResolver)
+    private val metricsCollector = MetricsCollectorLegacy(metricsReporter, nameScrubber)
+    private val producerServiceUser = "dummySystembruker"
+    private val producerNamespace = "namespace"
+    private val producerAppName = "appName"
+    private val mapper = ServiceUserMapper(mapOf(producerServiceUser to NamespaceAppName(producerNamespace, producerAppName)))
+    private val oppgaveTransformer = OppgaveLegacyTransformer(mapper)
+    private val feilresponsTransformer = FeilresponsLegacyTransformer(mapper)
+
+    private val goodEvents = createEvents(10)
+    private val badEvents = listOf(createEventWithTooLongGroupId("bad"))
+    private val oppgaveEvents = goodEvents.toMutableList().apply {
+        addAll(badEvents)
+    }.toMap()
+
+    @BeforeAll
+    fun setup() {
+        embeddedEnv.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        embeddedEnv.tearDown()
+    }
+
+    @Test
+    fun `Started Kafka instance in memory`() {
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
+    }
+
+    @Test
+    fun `Should read Oppgave-events and send to hoved-topic or error response topic as appropriate`() {
+        runBlocking {
+            KafkaTestUtil.produceEventsLegacy(testEnvironment, KafkaTestTopics.oppgaveLegacyTopicName, oppgaveEvents)
+        } shouldBeEqualTo true
+
+        `Read all Oppgave-events from our legacy-topic and verify that they have been sent to the main-topic`()
+
+        capturedInternalRecords.size `should be equal to` goodEvents.size
+        capturedErrorResponseRecords.size `should be equal to` badEvents.size
+    }
+
+
+    fun `Read all Oppgave-events from our legacy-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVE)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Oppgave>(consumerProps)
+
+        val oppgaveInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.OPPGAVEINTERN, TopicSource.ON_PREM)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, OppgaveIntern>(oppgaveInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.oppgaveInternTopicName, internalKafkaProducer)
+
+        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, TopicSource.ON_PREM)
+        val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
+        val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
+
+        val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+
+        val eventService = OppgaveLegacyEventService(oppgaveTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.oppgaveLegacyTopicName, kafkaConsumer, eventService)
+
+        internalKafkaProducer.initTransactions()
+        feilresponsKafkaProducer.initTransactions()
+        runBlocking {
+            consumer.startPolling()
+
+            `Wait until all oppgave events have been received by target topic`()
+            `Wait until bad event has been received by error topic`()
+
+            consumer.stopPolling()
+        }
+    }
+
+    private fun `Wait until all oppgave events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.OPPGAVEINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, OppgaveIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, OppgaveIntern>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.oppgaveInternTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var currentNumberOfRecords = 0
+
+        targetConsumer.startPolling()
+
+        while (currentNumberOfRecords < goodEvents.size) {
+            runBlocking {
+                currentNumberOfRecords = capturingProcessor.getEvents().size
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedInternalRecords.addAll(capturingProcessor.getEvents())
+    }
+
+
+    private fun `Wait until bad event has been received by error topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
+        val targetKafkaConsumer = KafkaConsumer<NokkelFeilrespons, Feilrespons>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelFeilrespons, Feilrespons>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.feilresponsTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var receivedEvent = false
+
+        targetConsumer.startPolling()
+
+        while (!receivedEvent) {
+            runBlocking {
+                receivedEvent = capturingProcessor.getEvents().isNotEmpty()
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedErrorResponseRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun createEvents(number: Int) = (1..number).map {
+        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createOppgaveLegacyWithGrupperingsId(it.toString())
+    }
+
+    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Oppgave> {
+        val groupId = "groupId".repeat(100)
+
+        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createOppgaveLegacyWithGrupperingsId(groupId)
+    }
+}

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputIT.kt
@@ -199,6 +199,6 @@ class StatusoppdateringInputIT {
     private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, StatusoppdateringInput>>): Pair<NokkelInput, StatusoppdateringInput> {
         val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
 
-        return return createNokkelInputWithEventId(existingEventId) to createStatusoppdateringInput()
+        return createNokkelInputWithEventId(existingEventId) to createStatusoppdateringInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputIT.kt
@@ -2,38 +2,31 @@ package no.nav.personbruker.brukernotifikasjonbestiller.statusoppdatering
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.brukernotifikasjon.schemas.Statusoppdatering
+import no.nav.brukernotifikasjon.schemas.input.StatusoppdateringInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.brukernotifikasjon.schemas.internal.StatusoppdateringIntern
 import no.nav.brukernotifikasjon.schemas.output.Feilrespons
 import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
-import no.nav.brukernotifikasjon.schemas.internal.StatusoppdateringIntern
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
 import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
-import no.nav.personbruker.brukernotifikasjonbestiller.common.getClient
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
 import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.AvroStatusoppdateringInputObjectMother.createStatusoppdateringInput
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.StatusoppdateringInputEventService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.NamespaceAppName
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMapper
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollectorLegacy
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameResolver
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameScrubber
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.TopicSource
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelLegacyObjectMother.createNokkelLegacyWithEventIdAndSystembruker
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.AvroStatusoppdateringLegacyObjectMother.createStatusoppdateringLegacyWithGrupperingsId
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.StatusoppdateringLegacyEventService
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.StatusoppdateringLegacyTransformer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.*
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother.createNokkelInputWithEventIdAndGroupId
 import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
@@ -43,11 +36,13 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.collections.ArrayList
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class StatusoppdateringIT {
+class StatusoppdateringInputIT {
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
-            KafkaTestTopics.statusoppdateringLegacyTopicName,
+            KafkaTestTopics.statusoppdateringInputTopicName,
             KafkaTestTopics.statusoppdateringInternTopicName,
             KafkaTestTopics.feilresponsTopicName
     ))
@@ -56,23 +51,19 @@ class StatusoppdateringIT {
     private val database = LocalPostgresDatabase()
 
     private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, StatusoppdateringIntern>>()
+
     private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
 
-    private val producerNameAlias = "dittnav"
-    private val client = getClient(producerNameAlias)
     private val metricsReporter = StubMetricsReporter()
-    private val nameResolver = ProducerNameResolver(client, testEnvironment.eventHandlerURL)
-    private val nameScrubber = ProducerNameScrubber(nameResolver)
-    private val metricsCollector = MetricsCollectorLegacy(metricsReporter, nameScrubber)
-    private val producerServiceUser = "dummySystembruker"
-    private val producerNamespace = "namespace"
-    private val producerAppName = "appName"
-    private val mapper = ServiceUserMapper(mapOf(producerServiceUser to NamespaceAppName(producerNamespace, producerAppName)))
-    private val statusoppdateringTransformer = StatusoppdateringLegacyTransformer(mapper)
-    private val feilresponsTransformer = FeilresponsLegacyTransformer(mapper)
+    private val metricsCollector = MetricsCollector(metricsReporter)
 
     private val goodEvents = createEvents(10)
-    private val badEvents = listOf(createEventWithTooLongGroupId("bad"))
+    private val badEvents = listOf(
+        createEventWithTooLongGroupId(),
+        createEventWithInvalidEventId(),
+        createEventWithDuplicateId(goodEvents)
+    )
+
     private val statusoppdateringEvents = goodEvents.toMutableList().apply {
         addAll(badEvents)
     }.toMap()
@@ -95,7 +86,7 @@ class StatusoppdateringIT {
     @Test
     fun `Should read Statusoppdatering-events and send to hoved-topic or error response topic as appropriate`() {
         runBlocking {
-            KafkaTestUtil.produceEvents(testEnvironment, KafkaTestTopics.statusoppdateringLegacyTopicName, statusoppdateringEvents)
+            KafkaTestUtil.produceEventsInput(testEnvironment, KafkaTestTopics.statusoppdateringInputTopicName, statusoppdateringEvents)
         } shouldBeEqualTo true
 
         `Read all Statusoppdatering-events from our input-topic and verify that they have been sent to the main-topic`()
@@ -104,25 +95,24 @@ class StatusoppdateringIT {
         capturedErrorResponseRecords.size `should be equal to` badEvents.size
     }
 
-
     fun `Read all Statusoppdatering-events from our input-topic and verify that they have been sent to the main-topic`() {
         val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.STATUSOPPDATERING)
-        val kafkaConsumer = KafkaConsumer<Nokkel, Statusoppdatering>(consumerProps)
+        val kafkaConsumer = KafkaConsumer<NokkelInput, StatusoppdateringInput>(consumerProps)
 
-        val statusoppdateringInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN, TopicSource.ON_PREM)
+        val statusoppdateringInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN, TopicSource.AIVEN)
         val internalKafkaProducer = KafkaProducer<NokkelIntern, StatusoppdateringIntern>(statusoppdateringInternProducerProps)
         val internalEventProducer = Producer(KafkaTestTopics.statusoppdateringInternTopicName, internalKafkaProducer)
 
-        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, TopicSource.ON_PREM)
+        val feilresponsProducerProps = Kafka.producerFeilresponsProps(testEnvironment, Eventtype.STATUSOPPDATERING, TopicSource.AIVEN)
         val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
         val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
 
         val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
         val eventDispatcher = EventDispatcher(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
 
-        val eventService = StatusoppdateringLegacyEventService(statusoppdateringTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
-        val consumer = Consumer(KafkaTestTopics.statusoppdateringLegacyTopicName, kafkaConsumer, eventService)
+        val eventService = StatusoppdateringInputEventService(metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.statusoppdateringInputTopicName, kafkaConsumer, eventService)
 
         internalKafkaProducer.initTransactions()
         feilresponsKafkaProducer.initTransactions()
@@ -135,6 +125,7 @@ class StatusoppdateringIT {
             consumer.stopPolling()
         }
     }
+
 
     private fun `Wait until all statusoppdatering events have been received by target topic`() {
         val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN)
@@ -160,7 +151,6 @@ class StatusoppdateringIT {
 
         capturedInternalRecords.addAll(capturingProcessor.getEvents())
     }
-
 
     private fun `Wait until bad event has been received by error topic`() {
         val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
@@ -188,12 +178,27 @@ class StatusoppdateringIT {
     }
 
     private fun createEvents(number: Int) = (1..number).map {
-        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createStatusoppdateringLegacyWithGrupperingsId(it.toString())
+        val eventId = UUID.randomUUID().toString()
+
+        createNokkelInputWithEventIdAndGroupId(eventId, it.toString()) to createStatusoppdateringInput()
     }
 
-    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Statusoppdatering> {
+    private fun createEventWithTooLongGroupId(): Pair<NokkelInput, StatusoppdateringInput> {
+        val eventId = UUID.randomUUID().toString()
         val groupId = "groupId".repeat(100)
 
-        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createStatusoppdateringLegacyWithGrupperingsId(groupId)
+        return createNokkelInputWithEventIdAndGroupId(eventId, groupId) to createStatusoppdateringInput()
+    }
+
+    private fun createEventWithInvalidEventId(): Pair<NokkelInput, StatusoppdateringInput> {
+        val eventId = "notUuidOrUlid"
+
+        return createNokkelInputWithEventId(eventId) to createStatusoppdateringInput()
+    }
+
+    private fun createEventWithDuplicateId(goodEvents: List<Pair<NokkelInput, StatusoppdateringInput>>): Pair<NokkelInput, StatusoppdateringInput> {
+        val existingEventId = goodEvents.first().let { (nokkel, _) -> nokkel.getEventId() }
+
+        return return createNokkelInputWithEventId(existingEventId) to createStatusoppdateringInput()
     }
 }

--- a/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyIT.kt
@@ -1,0 +1,199 @@
+package no.nav.personbruker.brukernotifikasjonbestiller.statusoppdatering
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.Statusoppdatering
+import no.nav.brukernotifikasjon.schemas.output.Feilrespons
+import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
+import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
+import no.nav.brukernotifikasjon.schemas.internal.StatusoppdateringIntern
+import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.brukernotifikasjonbestiller.CapturingEventProcessor
+import no.nav.personbruker.brukernotifikasjonbestiller.common.database.LocalPostgresDatabase
+import no.nav.personbruker.brukernotifikasjonbestiller.common.getClient
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaEmbed
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestTopics
+import no.nav.personbruker.brukernotifikasjonbestiller.common.kafka.KafkaTestUtil
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.RecordKeyValueWrapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.NamespaceAppName
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMapper
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Kafka
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollectorLegacy
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.TopicSource
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelLegacyObjectMother.createNokkelLegacyWithEventIdAndSystembruker
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.AvroStatusoppdateringLegacyObjectMother.createStatusoppdateringLegacyWithGrupperingsId
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.StatusoppdateringLegacyEventService
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.statusoppdatering.StatusoppdateringLegacyTransformer
+import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StatusoppdateringLegacyIT {
+    private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(
+            KafkaTestTopics.statusoppdateringLegacyTopicName,
+            KafkaTestTopics.statusoppdateringInternTopicName,
+            KafkaTestTopics.feilresponsTopicName
+    ))
+    private val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+
+    private val database = LocalPostgresDatabase()
+
+    private val capturedInternalRecords = ArrayList<RecordKeyValueWrapper<NokkelIntern, StatusoppdateringIntern>>()
+    private val capturedErrorResponseRecords = ArrayList<RecordKeyValueWrapper<NokkelFeilrespons, Feilrespons>>()
+
+    private val producerNameAlias = "dittnav"
+    private val client = getClient(producerNameAlias)
+    private val metricsReporter = StubMetricsReporter()
+    private val nameResolver = ProducerNameResolver(client, testEnvironment.eventHandlerURL)
+    private val nameScrubber = ProducerNameScrubber(nameResolver)
+    private val metricsCollector = MetricsCollectorLegacy(metricsReporter, nameScrubber)
+    private val producerServiceUser = "dummySystembruker"
+    private val producerNamespace = "namespace"
+    private val producerAppName = "appName"
+    private val mapper = ServiceUserMapper(mapOf(producerServiceUser to NamespaceAppName(producerNamespace, producerAppName)))
+    private val statusoppdateringTransformer = StatusoppdateringLegacyTransformer(mapper)
+    private val feilresponsTransformer = FeilresponsLegacyTransformer(mapper)
+
+    private val goodEvents = createEvents(10)
+    private val badEvents = listOf(createEventWithTooLongGroupId("bad"))
+    private val statusoppdateringEvents = goodEvents.toMutableList().apply {
+        addAll(badEvents)
+    }.toMap()
+
+    @BeforeAll
+    fun setup() {
+        embeddedEnv.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        embeddedEnv.tearDown()
+    }
+
+    @Test
+    fun `Started Kafka instance in memory`() {
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
+    }
+
+    @Test
+    fun `Should read Statusoppdatering-events and send to hoved-topic or error response topic as appropriate`() {
+        runBlocking {
+            KafkaTestUtil.produceEventsLegacy(testEnvironment, KafkaTestTopics.statusoppdateringLegacyTopicName, statusoppdateringEvents)
+        } shouldBeEqualTo true
+
+        `Read all Statusoppdatering-events from our legacy-topic and verify that they have been sent to the main-topic`()
+
+        capturedInternalRecords.size `should be equal to` goodEvents.size
+        capturedErrorResponseRecords.size `should be equal to` badEvents.size
+    }
+
+
+    fun `Read all Statusoppdatering-events from our legacy-topic and verify that they have been sent to the main-topic`() {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.STATUSOPPDATERING)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Statusoppdatering>(consumerProps)
+
+        val statusoppdateringInternProducerProps = Kafka.producerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN, TopicSource.ON_PREM)
+        val internalKafkaProducer = KafkaProducer<NokkelIntern, StatusoppdateringIntern>(statusoppdateringInternProducerProps)
+        val internalEventProducer = Producer(KafkaTestTopics.statusoppdateringInternTopicName, internalKafkaProducer)
+
+        val feilresponsProducerProps = Kafka.producerProps(testEnvironment, Eventtype.FEILRESPONS, TopicSource.ON_PREM)
+        val feilresponsKafkaProducer = KafkaProducer<NokkelFeilrespons, Feilrespons>(feilresponsProducerProps)
+        val feilresponsEventProducer = Producer(KafkaTestTopics.feilresponsTopicName, feilresponsKafkaProducer)
+
+        val brukernotifikasjonbestillingRepository = BrukernotifikasjonbestillingRepository(database)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository)
+        val eventDispatcher = EventDispatcher(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository, internalEventProducer, feilresponsEventProducer)
+
+        val eventService = StatusoppdateringLegacyEventService(statusoppdateringTransformer, feilresponsTransformer, metricsCollector, handleDuplicateEvents, eventDispatcher)
+        val consumer = Consumer(KafkaTestTopics.statusoppdateringLegacyTopicName, kafkaConsumer, eventService)
+
+        internalKafkaProducer.initTransactions()
+        feilresponsKafkaProducer.initTransactions()
+        runBlocking {
+            consumer.startPolling()
+
+            `Wait until all statusoppdatering events have been received by target topic`()
+            `Wait until bad event has been received by error topic`()
+
+            consumer.stopPolling()
+        }
+    }
+
+    private fun `Wait until all statusoppdatering events have been received by target topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.STATUSOPPDATERINGINTERN)
+        val targetKafkaConsumer = KafkaConsumer<NokkelIntern, StatusoppdateringIntern>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelIntern, StatusoppdateringIntern>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.statusoppdateringInternTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var currentNumberOfRecords = 0
+
+        targetConsumer.startPolling()
+
+        while (currentNumberOfRecords < goodEvents.size) {
+            runBlocking {
+                currentNumberOfRecords = capturingProcessor.getEvents().size
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedInternalRecords.addAll(capturingProcessor.getEvents())
+    }
+
+
+    private fun `Wait until bad event has been received by error topic`() {
+        val targetConsumerProps = KafkaEmbed.consumerProps(testEnvironment, Eventtype.FEILRESPONS)
+        val targetKafkaConsumer = KafkaConsumer<NokkelFeilrespons, Feilrespons>(targetConsumerProps)
+        val capturingProcessor = CapturingEventProcessor<NokkelFeilrespons, Feilrespons>()
+
+        val targetConsumer = Consumer(KafkaTestTopics.feilresponsTopicName, targetKafkaConsumer, capturingProcessor)
+
+        var receivedEvent = false
+
+        targetConsumer.startPolling()
+
+        while (!receivedEvent) {
+            runBlocking {
+                receivedEvent = capturingProcessor.getEvents().isNotEmpty()
+                delay(100)
+            }
+        }
+
+        runBlocking {
+            targetConsumer.stopPolling()
+        }
+
+        capturedErrorResponseRecords.addAll(capturingProcessor.getEvents())
+    }
+
+    private fun createEvents(number: Int) = (1..number).map {
+        createNokkelLegacyWithEventIdAndSystembruker(it.toString(), producerServiceUser) to createStatusoppdateringLegacyWithGrupperingsId(it.toString())
+    }
+
+    private fun createEventWithTooLongGroupId(eventId: String): Pair<Nokkel, Statusoppdatering> {
+        val groupId = "groupId".repeat(100)
+
+        return createNokkelLegacyWithEventIdAndSystembruker(eventId, producerServiceUser) to createStatusoppdateringLegacyWithGrupperingsId(groupId)
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/beskjed/BeskjedLegacyEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/beskjed/BeskjedLegacyEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
@@ -25,7 +25,7 @@ class BeskjedLegacyEventService(
     private val beskjedTransformer: BeskjedLegacyTransformer,
     private val feilresponsTransformer: FeilresponsLegacyTransformer,
     private val metricsCollector: MetricsCollectorLegacy,
-    private val handleDuplicateEvents: HandleDuplicateEvents,
+    private val handleDuplicateEvents: HandleDuplicateEventsLegacy,
     private val eventDispatcher: EventDispatcher<BeskjedIntern>
 ) : EventBatchProcessorService<Nokkel, Beskjed> {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/brukernotifikasjonbestilling/BrukernotifikasjonbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/brukernotifikasjonbestilling/BrukernotifikasjonbestillingRepository.kt
@@ -15,6 +15,18 @@ class BrukernotifikasjonbestillingRepository(private val database: Database) {
         }
     }
 
+    suspend fun fetchExistingEventIdsExcludingDone(eventIds: List<String>): List<String> {
+        return database.queryWithExceptionTranslation {
+            getExistingEventIdsExcludingDone(eventIds)
+        }
+    }
+
+    suspend fun fetchExistingEventIdsForDone(eventIds: List<String>): List<String> {
+        return database.queryWithExceptionTranslation {
+            getExistingEventIdsForDone(eventIds)
+        }
+    }
+
     suspend fun fetchDoneKeysThatMatchEventIds(eventIds: List<String>): List<DoneKey> {
         return database.queryWithExceptionTranslation {
             getDoneKeysByEventIds(eventIds)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/brukernotifikasjonbestilling/brukernotifikasjonbestillingQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/brukernotifikasjonbestilling/brukernotifikasjonbestillingQueries.kt
@@ -42,6 +42,22 @@ fun Connection.getEventKeysByEventIds(eventIds: List<String>): List<Brukernotifi
                     it.executeQuery().mapList { toBrukernotifikasjonKey() }
                 }
 
+fun Connection.getExistingEventIdsExcludingDone(eventIds: List<String>): List<String> =
+        prepareStatement("""SELECT eventId FROM brukernotifikasjonbestilling WHERE eventId= ANY(?) AND eventtype !=?""")
+                .use {
+                    it.setArray(1, createArrayOf("VARCHAR", eventIds.toTypedArray()))
+                    it.setString(2, Eventtype.DONE.toString())
+                    it.executeQuery().mapList { toEventIdString() }
+                }
+
+fun Connection.getExistingEventIdsForDone(eventIds: List<String>): List<String> =
+        prepareStatement("""SELECT eventId FROM brukernotifikasjonbestilling WHERE eventId= ANY(?) AND eventtype=?""")
+                .use {
+                    it.setArray(1, createArrayOf("VARCHAR", eventIds.toTypedArray()))
+                    it.setString(2, Eventtype.DONE.toString())
+                    it.executeQuery().mapList { toEventIdString() }
+                }
+
 fun Connection.getEventsByIds(eventId: String, systembruker: String, eventtype: Eventtype): List<Brukernotifikasjonbestilling> =
         prepareStatement("""SELECT * FROM brukernotifikasjonbestilling WHERE eventId=? AND systembruker=? AND eventtype=? """)
                 .use {
@@ -67,6 +83,10 @@ fun ResultSet.toBrukernotifikasjonKey(): BrukernotifikasjonKey {
             systembruker = getString("systembruker"),
             eventtype = toEventtype(getString("eventtype"))
     )
+}
+
+fun ResultSet.toEventIdString(): String {
+    return getString("eventId")
 }
 
 fun ResultSet.toDoneKey(): DoneKey {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsLegacy.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsLegacy.kt
@@ -4,11 +4,11 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 
-class HandleDuplicateDoneEvents(private val brukernotifikasjonbestillingRepository: BrukernotifikasjonbestillingRepository) {
+class HandleDuplicateEventsLegacy(private val eventtype: Eventtype, private val brukernotifikasjonbestillingRepository: BrukernotifikasjonbestillingRepository) {
 
     suspend fun <T> checkForDuplicateEvents(successfullyValidatedEvents: MutableList<Pair<NokkelIntern, T>>): DuplicateCheckResult<T> {
-        val checkDuplicatesInDbResult = getDuplicatesFromDb(successfullyValidatedEvents)
-        val checkDuplicatesWithinBatchResult = getDuplicatesWithinBatch(checkDuplicatesInDbResult.validEvents)
+        val checkDuplicatesInDbResult = getDuplicatesFromDb(eventtype, successfullyValidatedEvents)
+        val checkDuplicatesWithinBatchResult = getDuplicatesWithinBatch(eventtype, checkDuplicatesInDbResult.validEvents)
 
         val validEvents = checkDuplicatesWithinBatchResult.validEvents
         val allDuplicates = checkDuplicatesInDbResult.duplicateEvents + checkDuplicatesWithinBatchResult.duplicateEvents
@@ -19,35 +19,43 @@ class HandleDuplicateDoneEvents(private val brukernotifikasjonbestillingReposito
         )
     }
 
-    private suspend fun <T> getDuplicatesFromDb(events: List<Pair<NokkelIntern, T>>): DuplicateCheckResult<T> {
+    private suspend fun <T> getDuplicatesFromDb(eventtype: Eventtype, events: List<Pair<NokkelIntern, T>>): DuplicateCheckResult<T> {
         val eventIds = events.map { it.first.getEventId() }
 
-        val possibleDuplicates = brukernotifikasjonbestillingRepository.fetchExistingEventIdsForDone(eventIds).toSet()
+        val possibleDuplicates = brukernotifikasjonbestillingRepository.fetchBrukernotifikasjonKeysThatMatchEventIds(eventIds).toSet()
 
         return events.partition {
-            possibleDuplicates.doesNotContain(it.first.getEventId())
+            possibleDuplicates.doesNotContain(it.toBrukernotifikasjonKey(eventtype))
         }.let {
             DuplicateCheckResult(validEvents = it.first, duplicateEvents = it.second)
         }
     }
 
-    private fun <T> getDuplicatesWithinBatch(events: List<Pair<NokkelIntern, T>>): DuplicateCheckResult<T> {
+    private fun <T> getDuplicatesWithinBatch(eventtype: Eventtype, events: List<Pair<NokkelIntern, T>>): DuplicateCheckResult<T> {
         val validEvents = mutableListOf<Pair<NokkelIntern, T>>()
-        val validEventIds = mutableSetOf<String>()
+        val validEventKeys = mutableSetOf<BrukernotifikasjonKey>()
         val duplicateEvents = mutableListOf<Pair<NokkelIntern, T>>()
 
         events.forEach { event ->
-            val eventId = event.first.getEventId()
+            val key = event.toBrukernotifikasjonKey(eventtype)
 
-            if (validEventIds.doesNotContain(eventId)) {
+            if (validEventKeys.doesNotContain(key)) {
                 validEvents.add(event)
-                validEventIds.add(eventId)
+                validEventKeys.add(key)
             } else {
                 duplicateEvents.add(event)
             }
         }
 
         return DuplicateCheckResult(validEvents, duplicateEvents)
+    }
+
+    private fun <T> Pair<NokkelIntern, T>.toBrukernotifikasjonKey(eventtype: Eventtype): BrukernotifikasjonKey {
+        return BrukernotifikasjonKey(
+                first.getEventId(),
+                first.getSystembruker(),
+                eventtype
+        )
     }
 
     private fun <T> Set<T>.doesNotContain(entry: T) = !contains(entry)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/config/ApplicationContext.kt
@@ -9,9 +9,7 @@ import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedIn
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedLegacyEventService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.BeskjedLegacyTransformer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEvents
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.*
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.database.Database
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Consumer
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.Producer
@@ -87,7 +85,7 @@ class ApplicationContext {
 
     private fun initializeBeskjedLegacyProcessor(): Consumer<Nokkel, Beskjed> {
         val consumerProps = Kafka.consumerPropsLegacy(environment, Eventtype.BESKJED)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.BESKJED, ON_PREM)
         val beskjedEventDispatcher = EventDispatcher(Eventtype.BESKJED, brukernotifikasjonbestillingRepository, internBeskjedKafkaProducerLegacy, feilresponsKafkaProducer)
         val beskjedTransformer = BeskjedLegacyTransformer(serviceUserMapper)
@@ -98,7 +96,7 @@ class ApplicationContext {
 
     private fun initializeBeskjedInputProcessor(): Consumer<NokkelInput, BeskjedInput> {
         val consumerProps = Kafka.consumerProps(environment, Eventtype.BESKJED)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.BESKJED, AIVEN)
         val beskjedEventDispatcher = EventDispatcher(Eventtype.BESKJED, brukernotifikasjonbestillingRepository, internBeskjedKafkaProducer, feilresponsKafkaProducer)
         val beskjedEventService = BeskjedInputEventService(metricsCollector, handleDuplicateEvents, beskjedEventDispatcher)
@@ -107,7 +105,7 @@ class ApplicationContext {
 
     private fun initializeOppgaveLegacyProcessor(): Consumer<Nokkel, Oppgave> {
         val consumerProps = Kafka.consumerPropsLegacy(environment, Eventtype.OPPGAVE)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.OPPGAVE, ON_PREM)
         val oppgaveEventDispatcher = EventDispatcher(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository, internOppgaveKafkaProducerLegacy, feilresponsKafkaProducer)
         val oppgaveTransformer = OppgaveLegacyTransformer(serviceUserMapper)
@@ -118,7 +116,7 @@ class ApplicationContext {
 
     private fun initializeOppgaveInputProcessor(): Consumer<NokkelInput, OppgaveInput> {
         val consumerProps = Kafka.consumerProps(environment, Eventtype.OPPGAVE)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.OPPGAVE, AIVEN)
         val oppgaveEventDispatcher = EventDispatcher(Eventtype.OPPGAVE, brukernotifikasjonbestillingRepository, internOppgaveKafkaProducer, feilresponsKafkaProducer)
         val oppgaveEventService = OppgaveInputEventService(metricsCollector, handleDuplicateEvents, oppgaveEventDispatcher)
@@ -127,7 +125,7 @@ class ApplicationContext {
 
     private fun initializeInnboksLegacyProcessor(): Consumer<Nokkel, Innboks> {
         val consumerProps = Kafka.consumerPropsLegacy(environment, Eventtype.INNBOKS)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.INNBOKS, ON_PREM)
         val innboksEventDispatcher = EventDispatcher(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository, internInnboksKafkaProducerLegacy, feilresponsKafkaProducer)
         val innboksTransformer = InnboksLegacyTransformer(serviceUserMapper)
@@ -138,7 +136,7 @@ class ApplicationContext {
 
     private fun initializeInnboksInputProcessor(): Consumer<NokkelInput, InnboksInput> {
         val consumerProps = Kafka.consumerProps(environment, Eventtype.INNBOKS)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.INNBOKS, AIVEN)
         val innboksEventDispatcher = EventDispatcher(Eventtype.INNBOKS, brukernotifikasjonbestillingRepository, internInnboksKafkaProducer, feilresponsKafkaProducer)
         val innboksEventService = InnboksInputEventService(metricsCollector, handleDuplicateEvents, innboksEventDispatcher)
@@ -147,7 +145,7 @@ class ApplicationContext {
 
     private fun initializeStatusoppdateringLegacyProcessor(): Consumer<Nokkel, Statusoppdatering> {
         val consumerProps = Kafka.consumerPropsLegacy(environment, Eventtype.STATUSOPPDATERING)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.STATUSOPPDATERING, ON_PREM)
         val statusoppdateringEventDispatcher = EventDispatcher(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository, internStatusoppdateringKafkaProducerLegacy, feilresponsKafkaProducer)
         val statusoppdateringTransformer = StatusoppdateringLegacyTransformer(serviceUserMapper)
@@ -158,7 +156,7 @@ class ApplicationContext {
 
     private fun initializeStatusoppdateringInputProcessor(): Consumer<NokkelInput, StatusoppdateringInput> {
         val consumerProps = Kafka.consumerProps(environment, Eventtype.STATUSOPPDATERING)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.STATUSOPPDATERING, AIVEN)
         val statusoppdateringEventDispatcher = EventDispatcher(Eventtype.STATUSOPPDATERING, brukernotifikasjonbestillingRepository, internStatusoppdateringKafkaProducer, feilresponsKafkaProducer)
         val statusoppdateringEventService = StatusoppdateringInputEventService(metricsCollector, handleDuplicateEvents, statusoppdateringEventDispatcher)
@@ -167,7 +165,7 @@ class ApplicationContext {
 
     private fun initializeDoneLegacyProcessor(): Consumer<Nokkel, Done> {
         val consumerProps = Kafka.consumerPropsLegacy(environment, Eventtype.DONE)
-        val handleDuplicateDoneEvents = HandleDuplicateDoneEvents(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateDoneEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.DONE, ON_PREM)
         val doneEventDispatcher = EventDispatcher(Eventtype.DONE, brukernotifikasjonbestillingRepository, internDoneKafkaProducerLegacy, feilresponsKafkaProducer)
         val doneTransformer = DoneLegacyTransformer(serviceUserMapper)
@@ -178,7 +176,7 @@ class ApplicationContext {
 
     private fun initializeDoneInputProcessor(): Consumer<NokkelInput, DoneInput> {
         val consumerProps = Kafka.consumerProps(environment, Eventtype.DONE)
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEvents(brukernotifikasjonbestillingRepository)
         val feilresponsKafkaProducer = initializeFeilresponsProducer(Eventtype.DONE, AIVEN)
         val doneEventDispatcher = EventDispatcher(Eventtype.DONE, brukernotifikasjonbestillingRepository, internDoneKafkaProducer, feilresponsKafkaProducer)
         val doneEventService = DoneInputEventService(metricsCollector, handleDuplicateEvents, doneEventDispatcher)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneInputEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneInputEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEvents
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory
 
 class DoneInputEventService(
     private val metricsCollector: MetricsCollector,
-    private val handleDuplicateEvents: HandleDuplicateEvents,
+    private val handleDuplicateEvents: HandleDuplicateDoneEvents,
     private val eventDispatcher: EventDispatcher<DoneIntern>
 ) : EventBatchProcessorService<NokkelInput, DoneInput> {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneLegacyEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneLegacyEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
@@ -25,7 +25,7 @@ class DoneLegacyEventService(
     private val doneTransformer: DoneLegacyTransformer,
     private val feilresponsTransformer: FeilresponsLegacyTransformer,
     private val metricsCollector: MetricsCollectorLegacy,
-    private val handleDuplicateEvents: HandleDuplicateDoneEvents,
+    private val handleDuplicateEvents: HandleDuplicateDoneEventsLegacy,
     private val eventDispatcher: EventDispatcher<DoneIntern>
 ) : EventBatchProcessorService<Nokkel, Done> {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksLegacyEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksLegacyEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.output.NokkelFeilrespons
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
@@ -25,7 +25,7 @@ class InnboksLegacyEventService(
     private val innboksTransformer: InnboksLegacyTransformer,
     private val feilresponsTransformer: FeilresponsLegacyTransformer,
     private val metricsCollector: MetricsCollectorLegacy,
-    private val handleDuplicateEvents: HandleDuplicateEvents,
+    private val handleDuplicateEvents: HandleDuplicateEventsLegacy,
     private val eventDispatcher: EventDispatcher<InnboksIntern>
 ) : EventBatchProcessorService<Nokkel, Innboks> {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveLegacyEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveLegacyEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
@@ -25,7 +25,7 @@ class OppgaveLegacyEventService(
     private val oppgaveTransformer: OppgaveLegacyTransformer,
     private val feilresponsTransformer: FeilresponsLegacyTransformer,
     private val metricsCollector: MetricsCollectorLegacy,
-    private val handleDuplicateEvents: HandleDuplicateEvents,
+    private val handleDuplicateEvents: HandleDuplicateEventsLegacy,
     private val eventDispatcher: EventDispatcher<OppgaveIntern>
 ) : EventBatchProcessorService<Nokkel, Oppgave> {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyEventService.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.brukernotifikasjon.schemas.internal.StatusoppdateringIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.exception.NokkelNullException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.kafka.serializer.getNonNullKey
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
@@ -25,7 +25,7 @@ class StatusoppdateringLegacyEventService(
     private val statusoppdateringTransformer: StatusoppdateringLegacyTransformer,
     private val feilresponsTransformer: FeilresponsLegacyTransformer,
     private val metricsCollector: MetricsCollectorLegacy,
-    private val handleDuplicateEvents: HandleDuplicateEvents,
+    private val handleDuplicateEvents: HandleDuplicateEventsLegacy,
     private val eventDispatcher: EventDispatcher<StatusoppdateringIntern>
 ) : EventBatchProcessorService<Nokkel, Statusoppdatering> {
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/beskjed/BeskjedLegacyEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/beskjed/BeskjedLegacyEventServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.BeskjedIntern
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneLegacyObjectMother
@@ -29,7 +29,7 @@ internal class BeskjedLegacyEventServiceTest {
     private val topic = "topic-beskjed-test"
     private val transformer = mockk<BeskjedLegacyTransformer>()
     private val feilresponsTransformer = mockk<FeilresponsLegacyTransformer>()
-    private val handleDuplicateEvents = mockk<HandleDuplicateEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateEventsLegacy>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<BeskjedIntern>>(relaxed = true)
     private val internalEvents = AvroBeskjedInternObjectMother.giveMeANumberOfInternalBeskjedEvents(2, "systembruker", "eventId", "fodselsnummer")
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateDoneEventsLegacyTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateDoneEventsLegacyTest.kt
@@ -11,7 +11,7 @@ import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
-internal class HandleDuplicateDoneEventsTest {
+internal class HandleDuplicateDoneEventsLegacyTest {
     private val fodselsnummer = "123"
     private val eventId = "eventId"
     private val systembruker = "systembruker"
@@ -19,7 +19,7 @@ internal class HandleDuplicateDoneEventsTest {
 
     @Test
     fun `Skal returnere hele listen med vellykket eventer hvis ikke det finnes duplikat`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEvents(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
         val successfullyValidatedEvents = AvroDoneInternObjectMother.giveMeANumberOfInternalDoneEvents(numberOfEvents = 3, eventId = eventId, systembruker = systembruker, fodselsnummer = fodselsnummer)
         val expectedEventSize = successfullyValidatedEvents.size
 
@@ -37,7 +37,7 @@ internal class HandleDuplicateDoneEventsTest {
 
     @Test
     fun `Skal filtere ut eventer som allerede finnes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEvents(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
 
         val nokkelDuplicate = createNokkelIntern("$systembruker-0", "$eventId-0", fodselsnummer)
         val nokkelValid = createNokkelIntern("$systembruker-2", "$eventId-2", fodselsnummer)
@@ -69,7 +69,7 @@ internal class HandleDuplicateDoneEventsTest {
 
     @Test
     fun `Skal plassere duplikater innen samme batch i validEvents og duplicateEvents dersom de ikke allerede fantes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEvents(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
 
         val nokkelDuplicate = createNokkelIntern("$systembruker-0", "$eventId-0", fodselsnummer)
         val nokkelValid = createNokkelIntern("$systembruker-2", "$eventId-2", fodselsnummer)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateDoneEventsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateDoneEventsTest.kt
@@ -5,26 +5,25 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneInternObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
-internal class HandleDuplicateDoneEventsLegacyTest {
+internal class HandleDuplicateDoneEventsTest {
     private val fodselsnummer = "123"
     private val eventId = "eventId"
-    private val systembruker = "systembruker"
+    private val appnavn = "appnavn"
     private val brukernotifikasjonbestillingRepository = mockk<BrukernotifikasjonbestillingRepository>()
 
     @Test
     fun `Skal returnere hele listen med vellykket eventer hvis ikke det finnes duplikat`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
-        val successfullyValidatedEvents = AvroDoneInternObjectMother.giveMeANumberOfInternalDoneEvents(numberOfEvents = 3, eventId = eventId, systembruker = systembruker, fodselsnummer = fodselsnummer)
+        val handleDuplicateEvents = HandleDuplicateDoneEvents(brukernotifikasjonbestillingRepository)
+        val successfullyValidatedEvents = AvroDoneInternObjectMother.giveMeANumberOfInternalDoneEvents(numberOfEvents = 3, eventId = eventId, systembruker = appnavn, fodselsnummer = fodselsnummer)
         val expectedEventSize = successfullyValidatedEvents.size
 
         coEvery {
-            brukernotifikasjonbestillingRepository.fetchDoneKeysThatMatchEventIds(any())
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsForDone(any())
         } returns emptyList()
 
         val result = runBlocking {
@@ -37,16 +36,16 @@ internal class HandleDuplicateDoneEventsLegacyTest {
 
     @Test
     fun `Skal filtere ut eventer som allerede finnes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEvents(brukernotifikasjonbestillingRepository)
 
-        val nokkelDuplicate = createNokkelIntern("$systembruker-0", "$eventId-0", fodselsnummer)
-        val nokkelValid = createNokkelIntern("$systembruker-2", "$eventId-2", fodselsnummer)
+        val nokkelDuplicate = createNokkelIntern("$appnavn-0", "$eventId-0", fodselsnummer)
+        val nokkelValid = createNokkelIntern("$appnavn-2", "$eventId-2", fodselsnummer)
         val doneIntern = AvroDoneInternObjectMother.createDoneIntern()
 
-        val duplicateInDb = DoneKey(nokkelDuplicate.getEventId(), nokkelDuplicate.getSystembruker(), Eventtype.DONE, nokkelDuplicate.getFodselsnummer())
+        val duplicateInDb = nokkelDuplicate.getEventId()
 
         coEvery {
-            brukernotifikasjonbestillingRepository.fetchDoneKeysThatMatchEventIds(any())
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsForDone(any())
         } returns listOf(duplicateInDb)
 
         val successfullyValidatedEvents = mutableListOf(
@@ -69,14 +68,14 @@ internal class HandleDuplicateDoneEventsLegacyTest {
 
     @Test
     fun `Skal plassere duplikater innen samme batch i validEvents og duplicateEvents dersom de ikke allerede fantes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateDoneEventsLegacy(Eventtype.DONE, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateDoneEvents(brukernotifikasjonbestillingRepository)
 
-        val nokkelDuplicate = createNokkelIntern("$systembruker-0", "$eventId-0", fodselsnummer)
-        val nokkelValid = createNokkelIntern("$systembruker-2", "$eventId-2", fodselsnummer)
+        val nokkelDuplicate = createNokkelIntern("$appnavn-0", "$eventId-0", fodselsnummer)
+        val nokkelValid = createNokkelIntern("$appnavn-2", "$eventId-2", fodselsnummer)
         val doneIntern = AvroDoneInternObjectMother.createDoneIntern()
 
         coEvery {
-            brukernotifikasjonbestillingRepository.fetchDoneKeysThatMatchEventIds(any())
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsForDone(any())
         } returns emptyList()
 
         val successfullyValidatedEvents =
@@ -99,15 +98,15 @@ internal class HandleDuplicateDoneEventsLegacyTest {
         result.duplicateEvents `should contain` eventWithDuplicate
     }
 
-    fun createNokkelIntern(systembruker: String, eventId: String, fnr: String): NokkelIntern {
+    fun createNokkelIntern(appnavn: String, eventId: String, fnr: String): NokkelIntern {
         return NokkelIntern(
                 "12345",
                 eventId,
                 "123",
                 fnr,
                 "namespace",
-                "$systembruker-app",
-                systembruker
+                appnavn,
+                "N/A"
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsLegacyTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsLegacyTest.kt
@@ -11,7 +11,7 @@ import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
-internal class HandleDuplicateEventsTest {
+internal class HandleDuplicateEventsLegacyTest {
 
     private val fodselsnummer = "123"
     private val eventId = "eventId"
@@ -20,7 +20,7 @@ internal class HandleDuplicateEventsTest {
 
     @Test
     fun `Skal returnere hele listen med vellykket eventer hvis ikke det finnes duplikat`() {
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
         val successfullyValidatedEvents = AvroBeskjedInternObjectMother.giveMeANumberOfInternalBeskjedEvents(numberOfEvents = 3, eventId = eventId, systembruker = systembruker, fodselsnummer = fodselsnummer)
         val expectedEventSize = successfullyValidatedEvents.size
 
@@ -38,7 +38,7 @@ internal class HandleDuplicateEventsTest {
 
     @Test
     fun `Skal filtere ut eventer som allerede finnes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
 
         val nokkelDuplicate = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-0", "123", fodselsnummer, "namespace", "app","$systembruker-0")
         val nokkelValid = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-2", "123", fodselsnummer, "namespace", "app","$systembruker-2")
@@ -72,7 +72,7 @@ internal class HandleDuplicateEventsTest {
 
     @Test
     fun `Skal plassere duplikater innen samme batch i validEvents og duplicateEvents dersom de ikke allerede fantes i basen`() {
-        val handleDuplicateEvents = HandleDuplicateEvents(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
+        val handleDuplicateEvents = HandleDuplicateEventsLegacy(Eventtype.BESKJED, brukernotifikasjonbestillingRepository)
 
         val nokkelDuplicate = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-0", "123", fodselsnummer, "namespace", "app","$systembruker-0")
         val nokkelValid = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-2", "123", fodselsnummer, "namespace", "app","$systembruker-2")

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/common/HandleDuplicateEventsTest.kt
@@ -1,0 +1,105 @@
+package no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.beskjed.AvroBeskjedInternObjectMother
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.brukernotifikasjonbestilling.BrukernotifikasjonbestillingRepository
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.AvroNokkelInternObjectMother
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.config.Eventtype
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should contain`
+import org.junit.jupiter.api.Test
+
+internal class HandleDuplicateEventsTest {
+
+    private val fodselsnummer = "123"
+    private val eventId = "eventId"
+    private val systembruker = "systembruker"
+    private val brukernotifikasjonbestillingRepository = mockk<BrukernotifikasjonbestillingRepository>()
+
+    @Test
+    fun `Skal returnere hele listen med vellykket eventer hvis ikke det finnes duplikat`() {
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+        val successfullyValidatedEvents = AvroBeskjedInternObjectMother.giveMeANumberOfInternalBeskjedEvents(numberOfEvents = 3, eventId = eventId, systembruker = systembruker, fodselsnummer = fodselsnummer)
+        val expectedEventSize = successfullyValidatedEvents.size
+
+        coEvery {
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsExcludingDone(any())
+        } returns emptyList()
+
+        val result = runBlocking {
+            handleDuplicateEvents.checkForDuplicateEvents(successfullyValidatedEvents)
+        }
+
+        result.validEvents.size `should be equal to` expectedEventSize
+        result.duplicateEvents.size `should be equal to` 0
+    }
+
+    @Test
+    fun `Skal filtere ut eventer som allerede finnes i basen`() {
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+
+        val nokkelDuplicate = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-0", "123", fodselsnummer, "namespace", "app","$systembruker-0")
+        val nokkelValid = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-2", "123", fodselsnummer, "namespace", "app","$systembruker-2")
+        val beskjedIntern = AvroBeskjedInternObjectMother.createBeskjedIntern()
+
+        val duplicateInDb = nokkelDuplicate.getEventId()
+
+        coEvery {
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsExcludingDone(any())
+        } returns listOf(duplicateInDb)
+
+        val successfullyValidatedEvents = mutableListOf(
+                Pair(nokkelDuplicate, beskjedIntern),
+                Pair(nokkelValid, beskjedIntern)
+        )
+
+
+        val normalEvent = Pair(nokkelValid, beskjedIntern)
+        val eventWithDuplicate = Pair(nokkelDuplicate, beskjedIntern)
+        val expectedEvents = listOf(normalEvent)
+
+        val result = runBlocking {
+            handleDuplicateEvents.checkForDuplicateEvents(successfullyValidatedEvents)
+        }
+
+        result.validEvents.size `should be equal to` expectedEvents.size
+        result.validEvents `should contain` normalEvent
+        result.duplicateEvents `should contain` eventWithDuplicate
+    }
+
+
+    @Test
+    fun `Skal plassere duplikater innen samme batch i validEvents og duplicateEvents dersom de ikke allerede fantes i basen`() {
+        val handleDuplicateEvents = HandleDuplicateEvents(brukernotifikasjonbestillingRepository)
+
+        val nokkelDuplicate = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-0", "123", fodselsnummer, "namespace", "app","$systembruker-0")
+        val nokkelValid = AvroNokkelInternObjectMother.createNokkelIntern("12345", "$eventId-2", "123", fodselsnummer, "namespace", "app","$systembruker-2")
+        val beskjedIntern = AvroBeskjedInternObjectMother.createBeskjedIntern()
+
+        coEvery {
+            brukernotifikasjonbestillingRepository.fetchExistingEventIdsExcludingDone(any())
+        } returns emptyList()
+
+        val successfullyValidatedEvents =
+                mutableListOf(Pair(nokkelDuplicate, beskjedIntern),
+                        Pair(nokkelDuplicate, beskjedIntern),
+                        Pair(nokkelValid, beskjedIntern))
+
+
+        val normalEvent = Pair(nokkelValid, beskjedIntern)
+        val eventWithDuplicate = Pair(nokkelDuplicate, beskjedIntern)
+        val expectedEvents = listOf(normalEvent, eventWithDuplicate)
+
+        val result = runBlocking {
+            handleDuplicateEvents.checkForDuplicateEvents(successfullyValidatedEvents)
+        }
+
+        result.validEvents.size `should be equal to` expectedEvents.size
+        result.validEvents `should contain` normalEvent
+        result.validEvents `should contain` eventWithDuplicate
+        result.duplicateEvents `should contain` eventWithDuplicate
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneInputEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneInputEventServiceTest.kt
@@ -6,11 +6,8 @@ import no.nav.brukernotifikasjon.schemas.input.DoneInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.brukernotifikasjon.schemas.internal.DoneIntern
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.*
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneInputObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.EventMetricsSession
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.MetricsCollector
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.nokkel.AvroNokkelInputObjectMother
@@ -23,7 +20,7 @@ internal class DoneInputEventServiceTest {
     private val metricsCollector = mockk<MetricsCollector>(relaxed = true)
     private val metricsSession = mockk<EventMetricsSession>(relaxed = true)
     private val topic = "topic-done-test"
-    private val handleDuplicateEvents = mockk<HandleDuplicateEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateDoneEvents>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<DoneIntern>>(relaxed = true)
     private val internalEvents = AvroDoneInternObjectMother.giveMeANumberOfInternalDoneEvents(2, "systembruker", "eventId", "fodselsnummer")
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneLegacyEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/done/DoneLegacyEventServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.DoneIntern
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateDoneEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.feilrespons.FeilresponsLegacyTransformer
@@ -27,7 +27,7 @@ internal class DoneLegacyEventServiceTest {
     private val metricsCollector = mockk<MetricsCollectorLegacy>(relaxed = true)
     private val metricsSession = mockk<EventMetricsSessionLegacy>(relaxed = true)
     private val topic = "topic-done-test"
-    private val handleDuplicateEvents = mockk<HandleDuplicateDoneEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateDoneEventsLegacy>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<DoneIntern>>(relaxed = true)
     private val internalEvents = AvroDoneInternObjectMother.giveMeANumberOfInternalDoneEvents(2, "eventId", "systembruker", "fodselsnummer")
     private val transformer = mockk<DoneLegacyTransformer>()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksInputEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksInputEventServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneInputObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.EventMetricsSession

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksLegacyEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/innboks/InnboksLegacyEventServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.InnboksIntern
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneLegacyObjectMother
@@ -30,7 +30,7 @@ internal class InnboksLegacyEventServiceTest {
     private val topic = "topic-innboks-test"
     private val transformer = mockk<InnboksLegacyTransformer>()
     private val feilresponsTransformer = mockk<FeilresponsLegacyTransformer>()
-    private val handleDuplicateEvents = mockk<HandleDuplicateEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateEventsLegacy>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<InnboksIntern>>(relaxed = true)
     private val internalEvents = AvroInnboksInternObjectMother.giveMeANumberOfInternalInnboksEvents(2, "systembruker", "eventId", "fodselsnummer")
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveInputEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveInputEventServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneInputObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.EventMetricsSession

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveLegacyEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/oppgave/OppgaveLegacyEventServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneLegacyObjectMother
@@ -29,7 +29,7 @@ internal class OppgaveLegacyEventServiceTest {
     private val topic = "topic-oppgave-test"
     private val transformer = mockk<OppgaveLegacyTransformer>()
     private val feilresponsTransformer = mockk<FeilresponsLegacyTransformer>()
-    private val handleDuplicateEvents = mockk<HandleDuplicateEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateEventsLegacy>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<OppgaveIntern>>(relaxed = true)
     private val internalEvents = AvroOppgaveInternObjectMother.giveMeANumberOfInternalOppgaveEvents(2, "systembruker", "eventId", "fodselsnummer")
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringInputEventServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneInputObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.metrics.EventMetricsSession

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/statusoppdatering/StatusoppdateringLegacyEventServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.brukernotifikasjon.schemas.internal.StatusoppdateringIntern
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.DuplicateCheckResult
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.EventDispatcher
-import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEvents
+import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.HandleDuplicateEventsLegacy
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.common.serviceuser.ServiceUserMappingException
 import no.nav.personbruker.dittnav.brukernotifikasjonbestiller.done.AvroDoneLegacyObjectMother
@@ -29,7 +29,7 @@ internal class StatusoppdateringLegacyEventServiceTest {
     private val topic = "topic-statusoppdatering-test"
     private val transformer = mockk<StatusoppdateringLegacyTransformer>()
     private val feilresponsTransformer = mockk<FeilresponsLegacyTransformer>()
-    private val handleDuplicateEvents = mockk<HandleDuplicateEvents>(relaxed = true)
+    private val handleDuplicateEvents = mockk<HandleDuplicateEventsLegacy>(relaxed = true)
     private val eventDispatcher = mockk<EventDispatcher<StatusoppdateringIntern>>(relaxed = true)
     private val internalEvents = AvroStatusoppdateringInternObjectMother.giveMeANumberOfInternalStatusoppdateringEvents(2, "systembruker", "eventId", "fodselsnummer")
 


### PR DESCRIPTION
Strammer inn duplikatsjekk for input-topics slik at samme event-id ikke kan deles på tvers av eventtyper (utenom done).

Fikset feilaktig behandling av input-done. 