### PR TITLE
Legger til scheduler som melder at appen er nede hvis den har vært i live for lenge.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/AppExpiryChecker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/AppExpiryChecker.kt
@@ -1,0 +1,39 @@
+package no.nav.personbruker.dittnav.brukernotifikasjonbestiller.health
+
+import java.time.*
+
+class AppExpiryChecker (
+    private val expiryHourUTC: Int = 2,
+    private val expiryWindowMinutes: Int = 60,
+    private val minimumExpiryDurationMinutes: Int = 6 * 60,
+    private val appStartupTime: Instant = Instant.now()
+) {
+    init {
+        require(expiryWindowMinutes < minimumExpiryDurationMinutes) {
+            "'expiryWindowMinutes' må være mindre enn 'minimumExpiryDurationMinutes' for å forhindre unødig expiry."
+        }
+    }
+
+    fun isExpired(): Boolean {
+        return appLifetimeExceedsExpiry() && isWithinExpiryWindow()
+    }
+
+    private fun isWithinExpiryWindow(): Boolean {
+        val currentTimeUTC = LocalDateTime.now(ZoneOffset.UTC).toLocalTime()
+
+        val windowStart = LocalTime.of(expiryHourUTC, 0)
+        val windowEnd = windowStart.plusMinutes(expiryWindowMinutes.toLong())
+
+        return currentTimeUTC.isAfter(windowStart) && currentTimeUTC.isBefore(windowEnd)
+    }
+
+    private fun appLifetimeExceedsExpiry(): Boolean {
+        return minutesSinceAppStartup() > minimumExpiryDurationMinutes
+    }
+
+    private fun minutesSinceAppStartup(): Int {
+        val durationSinceStart = Duration.between(appStartupTime, Instant.now())
+
+        return durationSinceStart.toMinutes().toInt()
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/healthApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/healthApi.kt
@@ -8,7 +8,11 @@ import io.ktor.routing.get
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 
-fun Routing.healthApi(healthService: HealthService, collectorRegistry: CollectorRegistry = CollectorRegistry.defaultRegistry) {
+fun Routing.healthApi(
+    healthService: HealthService,
+    collectorRegistry: CollectorRegistry = CollectorRegistry.defaultRegistry,
+    appExpiryChecker: AppExpiryChecker = AppExpiryChecker()
+) {
 
     val pingJsonResponse = """{"ping": "pong"}"""
 
@@ -17,7 +21,11 @@ fun Routing.healthApi(healthService: HealthService, collectorRegistry: Collector
     }
 
     get("/internal/isAlive") {
-        call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        if (appExpiryChecker.isExpired()) {
+            call.respondText(text = "EXPIRED", status = HttpStatusCode.ServiceUnavailable, contentType = ContentType.Text.Plain)
+        } else {
+            call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        }
     }
 
     get("/internal/isReady") {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/AppExpiryCheckerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/brukernotifikasjonbestiller/health/AppExpiryCheckerTest.kt
@@ -1,0 +1,80 @@
+package no.nav.personbruker.dittnav.brukernotifikasjonbestiller.health
+
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+internal class AppExpiryCheckerTest {
+
+    @Test
+    fun `Should consider app expired if within expiry window and app lifetime is exceeded`() {
+        val windowStart = LocalTime.now(ZoneOffset.UTC).hour
+        val windowDurationMinutes = 120
+        val minLifetimeMinutes = 600
+        val appStartOffset = 1200L
+        val appStart = Instant.now().minus(appStartOffset, ChronoUnit.MINUTES)
+
+        val expiryChecker = AppExpiryChecker(
+            expiryHourUTC = windowStart,
+            expiryWindowMinutes = windowDurationMinutes,
+            minimumExpiryDurationMinutes = minLifetimeMinutes,
+            appStartupTime = appStart,
+        )
+
+        expiryChecker.isExpired() `should be equal to` true
+    }
+
+    @Test
+    fun `Should not consider app expired if within expiry window and app lifetime is not exceeded`() {
+        val windowStart = LocalTime.now(ZoneOffset.UTC).hour
+        val windowDurationMinutes = 120
+        val minLifetimeMinutes = 600
+        val appStartOffset = 300L
+        val appStart = Instant.now().minus(appStartOffset, ChronoUnit.MINUTES)
+
+        val expiryChecker = AppExpiryChecker(
+            expiryHourUTC = windowStart,
+            expiryWindowMinutes = windowDurationMinutes,
+            minimumExpiryDurationMinutes = minLifetimeMinutes,
+            appStartupTime = appStart,
+        )
+
+        expiryChecker.isExpired() `should be equal to` false
+    }
+
+    @Test
+    fun `Should not consider app exired if not within expiry window and app lifetime is exceeded`() {
+        val windowStart = (LocalTime.now(ZoneOffset.UTC).hour + 6) % 24
+        val windowDurationMinutes = 120
+        val minLifetimeMinutes = 600
+        val appStartOffset = 1200L
+        val appStart = Instant.now().minus(appStartOffset, ChronoUnit.MINUTES)
+
+        val expiryChecker = AppExpiryChecker(
+            expiryHourUTC = windowStart,
+            expiryWindowMinutes = windowDurationMinutes,
+            minimumExpiryDurationMinutes = minLifetimeMinutes,
+            appStartupTime = appStart,
+        )
+
+        expiryChecker.isExpired() `should be equal to` false
+    }
+
+    @Test
+    fun `Should not allow app lifetime shorter than window`() {
+        val windowDurationMinutes = 120
+        val minLifetimeMinutes = 60
+
+        invoking {
+            AppExpiryChecker(
+                expiryWindowMinutes = windowDurationMinutes,
+                minimumExpiryDurationMinutes = minLifetimeMinutes
+            )
+        } `should throw` Exception::class
+    }
+}


### PR DESCRIPTION
Dette er en workaround for en "scheduled restart," ettersom dette tilsynelatende ikke eksisterer for nais-apps.

Hensikten med dette er å forebygge problemer med kafka-pollere ved å tvinge regelmessig restart.

Slik fungerer sjekken ved kall til `/isAlive`:

Sjekk om klokka er innen et bestemt expiry-tidsom. Default er dette satt til utc 02:00-03:00.

Sjekk om appen har vært i minst en bestemt tid. Default er dette 6 timer. Dette gjøres for å unngå unødige eller gjentatte restarter.

Hvis begge disse sjekkene er sanne, vil `/isAlive` svare med en feilkode, slik at appen restartes av plattformen.